### PR TITLE
後期の時間割が表示されるようにした

### DIFF
--- a/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
+++ b/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
@@ -10,7 +10,7 @@ import Alamofire
 
 public protocol SuntechAPIClientProtocol {
     func login(email: String, password: String, completion: @escaping ((Result<LoginUser, DomainError>) -> ()))
-    func fetchWeekTimetable(studentId: String, password: String, completion: @escaping ((Result<WeekTimetable, AFError>) -> ()))
+    func fetchWeekTimetableFirst(studentId: String, password: String, completion: @escaping ((Result<WeekTimetable, AFError>) -> ()))
     func fetchVacations(completion: @escaping ((Result<[Vacation], AFError>) -> ()))
     
     func fetchChatroomList(userId: String, completion: @escaping ((Result<[Chatroom], AFError>) -> ()))
@@ -66,11 +66,11 @@ final class SuntechAPIClient: SuntechAPIClientProtocol {
             }
     }
     
-    func fetchWeekTimetable(studentId: String, password: String, completion: @escaping (Result<WeekTimetable, AFError>) -> ()) {
+    func fetchWeekTimetableFirst(studentId: String, password: String, completion: @escaping (Result<WeekTimetable, AFError>) -> ()) {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         
-        let path = "/api/timetable"
+        let path = "/api/timetable_first"
         
         let parameter = [
             "student_id": "\"\(studentId)\""

--- a/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
+++ b/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
@@ -82,6 +82,22 @@ final class SuntechAPIClient: SuntechAPIClientProtocol {
             }
     }
     
+    func fetchWeekTimetableSecond(studentId: String, password: String, completion: @escaping (Result<WeekTimetable, AFError>) -> ()) {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        let path = "/api/timetable_second"
+        
+        let parameter = [
+            "student_id": "\"\(studentId)\""
+        ]
+        
+        AF.request(baseURL + path, parameters: parameter)
+            .responseDecodable(of: WeekTimetable.self, decoder: decoder) { response in
+                completion(response.result)
+            }
+    }
+    
     func fetchVacations(completion: @escaping ((Result<[Vacation], AFError>) -> ())) {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
+++ b/SuntechProject_2024/API/SuntechAPI/SuntechAPIClient.swift
@@ -11,6 +11,7 @@ import Alamofire
 public protocol SuntechAPIClientProtocol {
     func login(email: String, password: String, completion: @escaping ((Result<LoginUser, DomainError>) -> ()))
     func fetchWeekTimetableFirst(studentId: String, password: String, completion: @escaping ((Result<WeekTimetable, AFError>) -> ()))
+    func fetchWeekTimetableSecond(studentId: String, password: String, completion: @escaping ((Result<WeekTimetable, AFError>) -> ()))
     func fetchVacations(completion: @escaping ((Result<[Vacation], AFError>) -> ()))
     
     func fetchChatroomList(userId: String, completion: @escaping ((Result<[Chatroom], AFError>) -> ()))

--- a/SuntechProject_2024/Feature/TimetableView/Top/TimetableView.swift
+++ b/SuntechProject_2024/Feature/TimetableView/Top/TimetableView.swift
@@ -21,7 +21,8 @@ struct TimetableView: View {
                     bounds: geometry.frame(in: .local),
                     today: $viewModel.today,
                     monday: $viewModel.monday,
-                    friday: $viewModel.friday
+                    friday: $viewModel.friday,
+                    month: $viewModel.month
                 )
                 .frame(height: 100)
                 
@@ -36,9 +37,6 @@ struct TimetableView: View {
                     Spacer()
                 }
             }
-        }
-        .onAppear {
-            viewModel.fetchWeekTimetable()
         }
         .backgroundColor(color: Color(R.color.common.backgroundColor))
         .navigationBarBackButtonHidden(true)

--- a/SuntechProject_2024/Feature/TimetableView/Top/TimetableView.swift
+++ b/SuntechProject_2024/Feature/TimetableView/Top/TimetableView.swift
@@ -63,7 +63,6 @@ struct TimetableView: View {
             }
         }
         .onTapGesture {
-            print(viewModel.vacation)
             viewModel.navigate(.classDetail(classData))
         }
     }

--- a/SuntechProject_2024/Feature/TimetableView/Top/TimetableViewModel.swift
+++ b/SuntechProject_2024/Feature/TimetableView/Top/TimetableViewModel.swift
@@ -17,6 +17,7 @@ final class TimetableViewModel: ObservableObject {
     @Published var today: Date?
     @Published var monday: Date?
     @Published var friday: Date?
+    @Published var month: Int = Calendar.current.component(.month, from: .now)
     
     private var cancellables = Set<AnyCancellable>()
     private let suntechAPIClient: SuntechAPIClientProtocol
@@ -43,6 +44,14 @@ final class TimetableViewModel: ObservableObject {
                         self.vacation = nil
                     }
                 }
+            }
+            .store(in: &cancellables)
+        
+        $month
+            .sink { [weak self] month in
+                guard let self else { return }
+                
+                self.fetchWeekTimetable()
             }
             .store(in: &cancellables)
         
@@ -74,19 +83,28 @@ final class TimetableViewModel: ObservableObject {
         guard let currentUser = LoginUserInfo.shared.currentUser,
               let password = LoginUserInfo.shared.password,
               let student = currentUser.user as? Student else { return }
-        
-        isLoading = true
-        
-        suntechAPIClient.fetchWeekTimetableFirst(studentId: student.id, password: password) { [weak self] result in
-            switch result {
-            case .success(let weekTimetable):
-                self?.weekTimetable = weekTimetable
-            case .failure(let error):
-                print(error)
+
+        if 4 <= month && month <= 8 { // 前期
+            suntechAPIClient.fetchWeekTimetableFirst(studentId: student.id, password: password) { [weak self] result in
+                switch result {
+                case .success(let weekTimetable):
+                    self?.weekTimetable = weekTimetable
+                case .failure(let error):
+                    print(error)
+                }
             }
-            
-            self?.isLoading = false
+        } else { // 後期
+            suntechAPIClient.fetchWeekTimetableSecond(studentId: student.id, password: password) { [weak self] result in
+                switch result {
+                case .success(let weekTimetable):
+                    self?.weekTimetable = weekTimetable
+                case .failure(let error):
+                    print(error)
+                }
+            }
         }
+        
+        
     }
     
     func fetchVacations() {

--- a/SuntechProject_2024/Feature/TimetableView/Top/TimetableViewModel.swift
+++ b/SuntechProject_2024/Feature/TimetableView/Top/TimetableViewModel.swift
@@ -77,7 +77,7 @@ final class TimetableViewModel: ObservableObject {
         
         isLoading = true
         
-        suntechAPIClient.fetchWeekTimetable(studentId: student.id, password: password) { [weak self] result in
+        suntechAPIClient.fetchWeekTimetableFirst(studentId: student.id, password: password) { [weak self] result in
             switch result {
             case .success(let weekTimetable):
                 self?.weekTimetable = weekTimetable

--- a/SuntechProject_2024/View/TimetableView/FSCalendarViewRepresentable.swift
+++ b/SuntechProject_2024/View/TimetableView/FSCalendarViewRepresentable.swift
@@ -13,6 +13,7 @@ struct FSCalendarViewRepresentable: UIViewRepresentable {
     @Binding var today: Date?
     @Binding var monday: Date?
     @Binding var friday: Date?
+    @Binding var month: Int
     
     typealias UIViewType = FSCalendarView
     
@@ -47,6 +48,7 @@ struct FSCalendarViewRepresentable: UIViewRepresentable {
             Task { @MainActor in
                 parent.monday = Calendar.current.date(byAdding: .day, value: 2, to: calendar.currentPage)
                 parent.friday = Calendar.current.date(byAdding: .day, value: 6, to: calendar.currentPage)
+                parent.month = Calendar.current.component(.month, from: calendar.currentPage)
             }
         }
     }


### PR DESCRIPTION
## 概要
- 後期の時間割が表示されるようにしました
- 4\~8月は前期、9~3月は後期の時間割が表示されます。

## スクリーンショット
<img src="https://github.com/Yuzuki0709/SuntechProject_2024/assets/73566377/24727021-a2da-4764-9e07-a40cf1896488" width="200">
